### PR TITLE
Update annotated-types requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 aiohttp==3.8.5
 aiosignal==1.3.1
-annotated-types==0.5.0
+annotated-types>=0.5.0
 anyio==3.7.1
 appnope==0.1.3
 asttokens==2.4.0


### PR DESCRIPTION
to allow versions greater than or equal to 0.5.0